### PR TITLE
[PROJETO] .env padrão do repositório

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+# .env
 .venv
 env/
 venv/

--- a/api/.env
+++ b/api/.env
@@ -1,0 +1,2 @@
+DATABASE_PROVIDER=sqlite
+DATABASE_FILENAME=devel.sqlite


### PR DESCRIPTION
Por questão de comodidade, prefiro manter o .env padrão, no repositório.

Não quero forçar quem não quiser configurar suas próprias informações, a fazer isso para testar.